### PR TITLE
implementation of portmapper set/unset procedures

### DIFF
--- a/nfs/nfs.go
+++ b/nfs/nfs.go
@@ -252,7 +252,7 @@ type FSInfo struct {
 	Properties uint32
 }
 
-// Dial an RPC svc after getting the port from the portmapper
+// DialService Dial an RPC svc after getting the port from the portmapper
 func DialService(addr string, prog rpc.Mapping) (*rpc.Client, error) {
 	pm, err := rpc.DialPortmapper("tcp", addr)
 	if err != nil {
@@ -328,7 +328,7 @@ func dialService(addr string, port int) (*rpc.Client, error) {
 }
 
 func isAddrInUse(err error) bool {
-	if er, ok := (err.(*net.OpError)); ok {
+	if er, ok := err.(*net.OpError); ok {
 		if syser, ok := er.Err.(*os.SyscallError); ok {
 			return syser.Err == syscall.EADDRINUSE
 		}

--- a/nfs/xdr/decode.go
+++ b/nfs/xdr/decode.go
@@ -23,6 +23,14 @@ func ReadUint32(r io.Reader) (uint32, error) {
 	return n, nil
 }
 
+func ReadBoolean(r io.Reader) (bool, error) {
+	var b bool
+	if err := Read(r, &b); err != nil {
+		return false, err
+	}
+	return b, nil
+}
+
 func ReadOpaque(r io.Reader) ([]byte, error) {
 	length, err := ReadUint32(r)
 	if err != nil {


### PR DESCRIPTION
implementation of portmapper set/unset procedures for registering nfs-server and mountd ports, which is necessary for windows mounts