### PR TITLE
nfs/xdr: make ReadOpaque use io.ReadFull and not assume one Read will work

### DIFF
--- a/nfs/xdr/decode.go
+++ b/nfs/xdr/decode.go
@@ -1,6 +1,6 @@
 // Copyright © 2017 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: BSD-2-Clause
-//
+
 package xdr
 
 import (
@@ -30,7 +30,7 @@ func ReadOpaque(r io.Reader) ([]byte, error) {
 	}
 
 	buf := make([]byte, length)
-	if _, err = r.Read(buf); err != nil {
+	if _, err = io.ReadFull(r, buf); err != nil {
 		return nil, err
 	}
 

--- a/nfs/xdr/decode_test.go
+++ b/nfs/xdr/decode_test.go
@@ -1,11 +1,14 @@
 // Copyright © 2017 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: BSD-2-Clause
-//
 package xdr
 
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"regexp"
 	"testing"
 
 	"github.com/willscott/go-nfs-client/nfs/util"
@@ -25,6 +28,55 @@ func TestRead(t *testing.T) {
 	}
 	buf := bytes.NewBuffer(b)
 	Read(buf, x)
+}
+
+// maxReadSizeReader is an io.Reader wrapper that bounds the size of each Read
+// call to at most n bytes.
+type maxReadSizeReader struct {
+	n int
+	r io.Reader
+}
+
+func (m maxReadSizeReader) Read(p []byte) (int, error) {
+	if len(p) > m.n {
+		p = p[:m.n]
+	}
+	return m.r.Read(p)
+}
+
+// TestReadOpaque verifies that ReadOpaque can read data correctly even when
+// the underlying reader returns less data than requested in a single io.Read
+// call. Previously the implementation of ReadOpaque assumed that io.Read would
+// act like io.ReadFull, which is not guaranteed by the io.Reader interface,
+// and that resulted in sporadic failures at load with short reads, depending on how
+// packets arrived and got buffered.
+func TestReadOpaque(t *testing.T) {
+	const nfsHandleHex = `
+	   00 00 00 40 90 14 1d 45 07 09 36 73 c9 96 8c 51
+   d9 71 07 37 34 ae 9b 4b 98 08 77 b6 de e6 5f 3e
+   e6 43 57 b0 cb b9 a2 35 56 35 4a f4 6d 38 45 f9
+   eb 1f 62 1d c5 7f 72 ac 79 dc b2 50 8f 5a 4e 08
+   8b f9 f2 37
+`
+	data, err := hex.DecodeString(regexp.MustCompile(`\s+`).ReplaceAllString(nfsHandleHex, ""))
+	if err != nil {
+		t.Fatalf("failed to decode hex: %v", err)
+	}
+
+	for i := 1; i <= len(data); i++ {
+		t.Run(fmt.Sprintf("maxReadSize=%d", i), func(t *testing.T) {
+			r := maxReadSizeReader{n: i, r: bytes.NewReader(data)}
+			got, err := ReadOpaque(r)
+			if err != nil {
+				t.Fatalf("failed to read opaque: %v", err)
+			}
+			const wantHex = "90141d4507093673c9968c51d971073734ae9b4b980877b6dee65f3ee64357b0cbb9a23556354af46d3845f9eb1f621dc57f72ac79dcb2508f5a4e088bf9f237"
+			gotHex := hex.EncodeToString(got)
+			if gotHex != wantHex {
+				t.Fatalf("opaque data mismatch:\n got:  %s\n want: %s", gotHex, wantHex)
+			}
+		})
+	}
 }
 
 func TestByteSlice(t *testing.T) {


### PR DESCRIPTION
@irbekrm noticed that NFS filehandle reads were getting truncated in production occasionally at arbitrary offsets and identified this code as the problem.